### PR TITLE
Fix deprecation warning for pip

### DIFF
--- a/.github/workflows/generate_routes.yml
+++ b/.github/workflows/generate_routes.yml
@@ -11,7 +11,7 @@ permissions:
   contents: write
 
 jobs:
-  build:
+  generate:
     runs-on: ubuntu-latest
 
     steps:
@@ -28,7 +28,7 @@ jobs:
       - name: Install Code Dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install --use-pep517 -r requirements.txt
 
       - name: Run generator script
         run: python generate.py


### PR DESCRIPTION
Fixes:
`DEPRECATION: ipcalc is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change.`